### PR TITLE
Add InternalPartyInfo.BillingAccountId, obsolete PortalGroupId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # История изменений
 
+## v1.3 - 2020.04.20
+- Добавлено свойство `BillingAccountId` в `InternalPartyInfo`. Это тоже самое, что `PortalGroupId`. `PortalGroupId` теперь obsolete и будет удалено в будущих версиях.
+
 ## v1.2 - 2020.04.05
 - Доработка метода `AddOrUpdateParty` для интеграции с Контур.Продажами (EDISUP-13100).
 - Метод `AddEmployee` использует POST-запрос.

--- a/EdiApi.Client/Types/Parties/InternalPartyInfo.cs
+++ b/EdiApi.Client/Types/Parties/InternalPartyInfo.cs
@@ -1,9 +1,15 @@
-﻿namespace SkbKontur.EdiApi.Client.Types.Parties
+using System;
+
+namespace SkbKontur.EdiApi.Client.Types.Parties
 {
     public class InternalPartyInfo : PartyInfo
     {
         public string ProviderPartyId { get; set; }
+
+        [Obsolete("Use BillingAccountId instead. These fields are equivalent and PortalGroupId will be removed in future releases.")]
         public string PortalGroupId { get; set; }
+
+        public string BillingAccountId { get; set; }
         public TradingPartnerSettings[] TradingPartnerSettings { get; set; }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2",
+  "version": "1.3",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
Add InternalPartyInfo.BillingAccountId, which is equivalent to InternalPartyInfo.PortalGroupId. PortalGroupId is obsolete now

После мержа пулл-реквеста добавлю заполнение поля в EDI 